### PR TITLE
Test 24 cases in 2 requests

### DIFF
--- a/payloads.txt
+++ b/payloads.txt
@@ -1,2 +1,2 @@
-.jsonp?callback=test&jsonp=test
-?callback=test&jsonp=test
+?callback=x&cb=x&jsonp=x&jsonpcallback=x&jsonpcb=x&jsonp_cb=x&json=x&jsoncallback=x&jcb=x&call=x&cb_=x&_cb_=x
+.jsonp?callback=x&cb=x&jsonp=x&jsonpcallback=x&jsonpcb=x&jsonp_cb=x&json=x&jsoncallback=x&jcb=x&call=x&cb_=x&_cb_=x

--- a/payloads.txt
+++ b/payloads.txt
@@ -1,4 +1,2 @@
 .jsonp?callback=test
-.jsonp
-?callback=test
-?jsonp=test
+?callback=test&jsonp=test

--- a/payloads.txt
+++ b/payloads.txt
@@ -1,2 +1,2 @@
-.jsonp?callback=test
+.jsonp?callback=test&jsonp=test
 ?callback=test&jsonp=test


### PR DESCRIPTION
Web applications do not acknowledge additional query parameters supplied in HTTP requests. Developers simply fetch whatever parameters they need from the request.

Hence, if `callback` parameter exists on an endpoint, sending both `callback` and `jsonp` parameters in the same request won't affect the application's behavior.

Using this simple deduction, we can reduce the number of requests by 50%.